### PR TITLE
Expose ingest.user_agent.cache_size

### DIFF
--- a/plugins/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/IngestUserAgentPlugin.java
+++ b/plugins/ingest-user-agent/src/main/java/org/elasticsearch/ingest/useragent/IngestUserAgentPlugin.java
@@ -37,7 +37,7 @@ import java.util.stream.Stream;
 
 public class IngestUserAgentPlugin extends Plugin implements IngestPlugin {
 
-    private final Setting<Long> CACHE_SIZE_SETTING = Setting.longSetting("ingest.user_agent.cache_size", 1000, 0,
+    public final Setting<Long> CACHE_SIZE_SETTING = Setting.longSetting("ingest.user_agent.cache_size", 1000, 0,
             Setting.Property.NodeScope);
 
     static final String DEFAULT_PARSER_NAME = "_default_";


### PR DESCRIPTION
We're experiencing high loads from user_agent parsing, and would like to have configurable user_agent cache size to be able to test/run with different settings.
